### PR TITLE
save and restore window view to prevent cursor from resetting

### DIFF
--- a/lua/deadcolumn/autocmds.lua
+++ b/lua/deadcolumn/autocmds.lua
@@ -76,7 +76,7 @@ local function redraw_colorcolumn()
   local cc = resolve_cc(vim.w.cc)
   if not cc then
     -- Save window view to prevent cursor
-    -- from being reset
+    -- from being reset.
     local winview = vim.fn.winsaveview()
     vim.wo.cc = ''
     vim.fn.winrestview(winview)
@@ -89,7 +89,7 @@ local function redraw_colorcolumn()
     thresh = math.floor(thresh * cc)
   end
   if
-      len < thresh or not vim.tbl_contains(configs.user.modes, vim.fn.mode())
+    len < thresh or not vim.tbl_contains(configs.user.modes, vim.fn.mode())
   then
     local winview = vim.fn.winsaveview()
     vim.wo.cc = ''

--- a/lua/deadcolumn/autocmds.lua
+++ b/lua/deadcolumn/autocmds.lua
@@ -75,11 +75,11 @@ end
 local function redraw_colorcolumn()
   local cc = resolve_cc(vim.w.cc)
   if not cc then
-    -- Only set vim.wo.cc when necessary,
-    -- prevent cursor position from being reset.
-    if vim.wo.cc ~= '' then
-      vim.wo.cc = ''
-    end
+    -- Save window view to prevent cursor
+    -- from being reset
+    local winview = vim.fn.winsaveview()
+    vim.wo.cc = ''
+    vim.fn.winrestview(winview)
     return
   end
 
@@ -89,17 +89,17 @@ local function redraw_colorcolumn()
     thresh = math.floor(thresh * cc)
   end
   if
-    len < thresh or not vim.tbl_contains(configs.user.modes, vim.fn.mode())
+      len < thresh or not vim.tbl_contains(configs.user.modes, vim.fn.mode())
   then
-    if vim.wo.cc ~= '' then
-      vim.wo.cc = ''
-    end
+    local winview = vim.fn.winsaveview()
+    vim.wo.cc = ''
+    vim.fn.winrestview(winview)
     return
   end
 
-  if vim.wo.cc ~= vim.w.cc then
-    vim.wo.cc = vim.w.cc
-  end
+  local winview = vim.fn.winsaveview()
+  vim.wo.cc = vim.w.cc
+  vim.fn.winrestview(winview)
 
   -- Show blended color when len < cc
   local normal_bg = colors.get_hl(
@@ -158,7 +158,9 @@ local function make_autocmds()
     group = 'AutoColorColumn',
     callback = function()
       store.previous_cc = vim.w.cc
+      local winview = vim.fn.winsaveview()
       vim.wo.cc = ''
+      vim.fn.winrestview(winview)
     end,
   })
 
@@ -221,7 +223,9 @@ local function make_autocmds()
   vim.api.nvim_create_autocmd({ 'BufLeave' }, {
     group = 'AutoColorColumn',
     callback = function()
+      local winview = vim.fn.winsaveview()
       vim.wo.cc = ''
+      vim.fn.winrestview(winview)
     end,
   })
   vim.api.nvim_create_autocmd({ 'BufWinEnter' }, {
@@ -230,7 +234,9 @@ local function make_autocmds()
       vim.b.cc = str_fallback(vim.wo.cc, vim.b.cc, vim.g.cc)
       vim.w.cc = str_fallback(vim.wo.cc, vim.b.cc, vim.g.cc)
       if not vim.tbl_contains(configs.user.modes, vim.fn.mode()) then
+        local winview = vim.fn.winsaveview()
         vim.wo.cc = ''
+        vim.fn.winrestview(winview)
       end
     end,
   })
@@ -257,7 +263,9 @@ local function make_autocmds()
         vim.b.cc = vim.wo.cc
       end
       vim.go.cc = ''
+      local winview = vim.fn.winsaveview()
       vim.wo.cc = ''
+      vim.fn.winrestview(winview)
     end,
   })
 


### PR DESCRIPTION
Removes the need to check `vim.wo.cc` before setting and still works properly, prevents cursor from being reset when switching tabs or buffers, etc.